### PR TITLE
FEAT: use bookfinder.com for ISBN links

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -29,8 +29,10 @@
   ],
   "ignoreWords": [
     "PyPI",
+    "bookfinder",
     "commitlint",
     "etal",
+    "isbnsearch",
     "prereleased",
     "rtfd",
     "sphinxcontrib",

--- a/README.md
+++ b/README.md
@@ -38,3 +38,9 @@ Alternatively, you can use the style for one bibliography only by specifying it 
 .. bibliography:: /references.bib
   :style: unsrt_et_al
 ```
+
+Book entries that have an ISBN get a link to the book entry on [bookfinder.com](https://bookfinder.com/search). If you want to use [isbnsearch.org](https://isbnsearch.org) instead, add the following to your `conf.py`:
+
+```python
+unsrt_etal_isbn_resolver = "isbnsearch"
+```


### PR DESCRIPTION
The website [isbnsearch.org](https://isbnsearch.org) is down quite often, see e.g. linkcheck for https://github.com/ComPWA/ampform/pull/371/commits/0c481d8ce010e857595959071946786cd4ce9a07. This PR switches to [bookfinder.com](https://www.bookfinder.com/isbn_search/) for resolving ISBN links instead. To get the old behavior, add the following to your `conf.py`:

```python
unsrt_etal_isbn_resolver = "isbnsearch"  # default "bookfinder"
```
